### PR TITLE
monorepo corrections

### DIFF
--- a/templates/monorepo/packages/shared/package.json
+++ b/templates/monorepo/packages/shared/package.json
@@ -5,12 +5,12 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "types": "./build/index.d.ts",
+      "import": "./build/index.js"
     },
     "./*": {
-      "types": "./dist/*.d.ts",
-      "import": "./dist/*.js"
+      "types": "./build/*.d.ts",
+      "import": "./build/*.js"
     }
   },
   "scripts": {

--- a/templates/monorepo/packages/shared/src/index.ts
+++ b/templates/monorepo/packages/shared/src/index.ts
@@ -1,7 +1,7 @@
 import { ArraySchema, MapSchema, Schema, type } from "@colyseus/schema";
 
 export class Item extends Schema {
-    @type("string") name: string;
+    @type("string") name!: string;
 }
 
 export class Player extends Schema {


### PR DESCRIPTION
Small, necessary fixes to properly build monorepo setup upon clean installation.

Corrects faulty build configuration in packages/shared pointing to `dist/` but builds to `build/`. Ensures proper type assurance inside of packages/shared/src/index.ts Item name.

```
~/create-colyseus-app |master → origin ↑1 ✓| →  node -v
v25.2.1
~/create-colyseus-app |master → origin ↑1 ✓| →  pnpm -v
10.28.1
```